### PR TITLE
Array memory overrun fix and ui_lang.h inclusion fix.

### DIFF
--- a/Repetier Firmware/Repetier/Printer.cpp
+++ b/Repetier Firmware/Repetier/Printer.cpp
@@ -859,9 +859,12 @@ void Printer::setup()
     Extruder::initExtruder();
     // sets autoleveling in eeprom init
     EEPROM::init(); // Read settings from eeprom if wanted
-    for(uint8_t i = 0; i < E_AXIS_ARRAY; i++)
+    for(uint8_t i = 0; i < sizeof(currentPositionSteps)/sizeof(currentPositionSteps[0]); i++)
     {
         currentPositionSteps[i] = 0;
+    }
+    for(uint8_t i = 0; i < sizeof(currentPosition)/sizeof(currentPosition[0]); i++)
+    {
         currentPosition[i] = 0.0;
     }
 //setAutolevelActive(false); // fixme delete me

--- a/Repetier Firmware/Repetier/uilang.h
+++ b/Repetier Firmware/Repetier/uilang.h
@@ -16,6 +16,12 @@
 
 */
 
+#ifndef UI_LANG_H
+#define UI_LANG_H
+
+// Include Configuration.h in order to load the correct language.
+#include "Configuration.h"
+
 #if !defined(UI_DISPLAY_CHARSET) || UI_DISPLAY_CHARSET>3
 #define UI_DISPLAY_CHARSET 1
 #endif
@@ -1796,5 +1802,7 @@
 #define UI_TEXT_CALIBRATING_HEIGHT       "Calibrating","Printer Z Height","","Please Wait"
 #define UI_TEXT_CALIBRATING_RADIUS       "Calibrating","Horizontal Radius","","Please Wait"
 #define UI_TEXT_CALIBRATING_BED       "Calibrating","Bed Level Matrix","","Please Wait"
+
+#endif
 
 #endif


### PR DESCRIPTION
There is an array memory overrun issue in Printer::setup due to the fact that currentPositionSteps and currentPosition are not the same length.  One has a length of 3 and the other has a length of 4.

Also fixed was the missing include guard on ui_lang.h and the inclusion of Configuration.h.  This ensures that ui_lang.h stays the same across the project.